### PR TITLE
Image Attribution Framework

### DIFF
--- a/schema_org.csv
+++ b/schema_org.csv
@@ -9,6 +9,7 @@ Dryad,r3d100000044,https://datadryad.org/,implemented
 Figshare,r3d100010066,https://figshare.com,implemented
 Harvard Dataverse,r3d100010051,https://dataverse.harvard.edu,implemented
 HEPData.net,r3d100010081,https://hepdata.net,implemented
+IAF,,http://iaf.virtualbrain.org/,implemented
 ICPSR,r3d100010255,https://www.icpsr.umich.edu/,implemented
 Kaggle,,https://www.kaggle.com,implemented
 Mendeley,r3d100011868,https://data.mendeley.com,implemented

--- a/schema_org.csv
+++ b/schema_org.csv
@@ -9,7 +9,7 @@ Dryad,r3d100000044,https://datadryad.org/,implemented
 Figshare,r3d100010066,https://figshare.com,implemented
 Harvard Dataverse,r3d100010051,https://dataverse.harvard.edu,implemented
 HEPData.net,r3d100010081,https://hepdata.net,implemented
-IAF,,http://iaf.virtualbrain.org/,implemented
+Image Attribution Framework,,http://iaf.virtualbrain.org/,implemented
 ICPSR,r3d100010255,https://www.icpsr.umich.edu/,implemented
 Kaggle,,https://www.kaggle.com,implemented
 Mendeley,r3d100011868,https://data.mendeley.com,implemented


### PR DESCRIPTION
IAF itself is only a prototype, but we used it to guide what we're currently implementing in NITRC-IR (https://www.nitrc.org/ir/, r3d100011515).  I'll update again when NITRC-IR is up to date.
